### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ approximate maximal influence".
 > library(devtools)
 > devtools::install_github("https://github.com/rgiordan/zaminfluence/",
                            ref="master",
+                           subdir="zaminfluence",
                            force=TRUE)
 ```
 


### PR DESCRIPTION
For me `install_github()` from the README failed since the R part is in a subfolder. I added the path so it installs properly.